### PR TITLE
Directus URL initialization with base path

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -147,14 +147,15 @@ class Plugin {
 
 		try {
 			const baseUrl = new URL(url);
-
-			baseUrl.pathname = '/';
+			const basePath = baseUrl.pathname;
+			
+			baseUrl.pathname = basePath;
 			this.url = baseUrl.toString();
 
-			baseUrl.pathname = '/graphql';
+			baseUrl.pathname = basePath + '/graphql';
 			this.urlGraphql = baseUrl.toString();
 
-			baseUrl.pathname = '/graphql/system';
+			baseUrl.pathname = basePath + '/graphql/system';
 			this.urlGraphqlSystem = baseUrl.toString();
 		} catch (err) {
 			error('"url" should be a valid URL');


### PR DESCRIPTION
When not served from root path  "http://my.dns.io/directus/", it allows Transport & Axios with 'baseURL' parameter to be well configured.