### PR TITLE
Handle concurrency on download images, only store node id in cache

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -148,7 +148,7 @@ class Plugin {
 		this.url = '';
 		this.refreshInterval = 0;
 		this.authPromise = null;
-		this.concurrency = 0;
+		this.concurrency = 10;
 	}
 
 	async setOptions(options) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -255,6 +255,7 @@ class Plugin {
 
 			const files = await this.directus.files
 				.readByQuery({
+					filter: { type: { _contains: 'image' } },
 					fields: ['id', 'type', 'filename_download'],
 					sort: ['id'],
 					limit: this.concurrency,

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,8 @@ query {
 - `graphql` [*Optional*] - defines extra options to be passed into `gatsby-source-graphql`. Useful for advanced use
   cases.
 
+- `concurrency` [*Optional, defaults to `10`*] - tells how much images tries to download concurrently
+
 ## How to query
 
 The default way to query data is to fetch items from `directus` field.


### PR DESCRIPTION
Awaiting creation of remote file nodes instead of returning after looping over them. Otherwise the creation of the remote file nodes might not be finished upon retrieving the data from the resolver.

Also, only store the node id in the cache & touch it to prevent garbage collection.