### PR TITLE
Fix headers promise

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -283,8 +283,9 @@ class Plugin {
 			Object.assign(headers, (await this.options.headers()) || {});
 		}
 
-		if (await this.directus.auth.token) {
-			const token = await this.directus.auth.token;
+		const token = await this.directus.auth.token;
+
+		if (token) {
 			Object.assign(headers, {
 				Authorization: `Bearer ${token}`,
 			});

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -283,9 +283,10 @@ class Plugin {
 			Object.assign(headers, (await this.options.headers()) || {});
 		}
 
-		if (this.directus.auth.token) {
+		if (await this.directus.auth.token) {
+			const token = await this.directus.auth.token;
 			Object.assign(headers, {
-				Authorization: `Bearer ${this.directus.auth.token}`,
+				Authorization: `Bearer ${token}`,
 			});
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/gatsby-source-directus",
-	"version": "9.14.6",
+	"version": "9.14.7",
 	"description": "Source plugin for pulling data into Gatsby from a Directus API.",
 	"author": "João Biondo <wolfulus@gmail.com>",
 	"license": "MIT",


### PR DESCRIPTION
this PR fixes headers returning incorrect bearer token as:

```
if (this.directus.auth.token) {
    Object.assign(headers, {
        Authorization: `Bearer ${this.directus.auth.token}`,
    });
}
```

would set `Bearer` token as a promise rather than the actual token.